### PR TITLE
tails.cfg: rm union_type

### DIFF
--- a/config/tails/tails.cfg
+++ b/config/tails/tails.cfg
@@ -13,7 +13,7 @@ for isofile in $iso_dir/$iso_pattern $iso_dir/$iso_subdir/$iso_pattern; do
 			iso_path="$2"
 			loopback loop $iso_path
 			isocfg="findiso=$iso_path"
-			bootoptions="boot=live config live-media=removable nopersistence noprompt timezone=Etc/UTC block.events_dfl_poll_msecs=1000 splash noautologin module=Tails slab_nomerge slub_debug=FZP mce=0 vsyscall=none page_poison=1 init_on_alloc=1 init_on_free=1 mds=full,nosmt union=aufs"
+			bootoptions="boot=live config live-media=removable nopersistence noprompt timezone=Etc/UTC block.events_dfl_poll_msecs=1000 splash noautologin module=Tails slab_nomerge slub_debug=FZP mce=0 vsyscall=none page_poison=1 init_on_alloc=1 init_on_free=1 mds=full,nosmt"
 			linux_path="(loop)/live/vmlinuz"
 			initrd_path="(loop)/live/initrd.img"
 


### PR DESCRIPTION
Remove this config option which is not working since https://gitlab.tails.boum.org/tails/tails/-/issues/17489 and https://gitlab.tails.boum.org/tails/tails/-/commit/50d133245d3559b0b3769965683ba75bf888e547

Trying to boot with it gave a prompt with error "aufs not found"