### PR TITLE
Update multios-usb.sh

### DIFF
--- a/multios-usb.sh
+++ b/multios-usb.sh
@@ -140,7 +140,7 @@ if [[ $updateOnly == yes ]]; then
 				true
 				;;
 			*)
-				echo -e '\nBad answer. Exiting...'
+				echo -e '\nAnswer not "YeS". Exiting...'
 				exit 1
 				;;
 		esac
@@ -251,7 +251,7 @@ case $yN in
 		true
 		;;
 	*)
-		echo 'Bad answer. Exiting...'
+		echo 'Answer not "YeS". Exiting...'
 		exit 1
 		;;
 esac


### PR DESCRIPTION
"Bad answer" isn't properly descriptive, if people answer `no` it is not bad, it is just a reason to be exiting (because the answer is not `YeS`).