### PR TITLE
Add Tiny11 pattern match to windows cfg

### DIFF
--- a/config/windows/windows_iso.cfg
+++ b/config/windows/windows_iso.cfg
@@ -9,7 +9,7 @@ for isofile in ($dev,*)$iso_dir/$iso_pattern1 ($dev,*)$iso_dir/$iso_pattern2; do
 	if [ -e "$isofile" ]; then
 		regexp --set=isoname "$iso_dir/(.*)" "$isofile"
 
-		menuentry "$isoname" "$isofile" "$iso_dir/$isoname" --class=windows {
+		menuentry "$isoname ->" "$isofile" "$iso_dir/$isoname" --class=windows {
 			if [ "${grub_platform}" != "efi" ]; then
 				rmmod iso9660
 				drivemap -s (hd0) (hd1)

--- a/config/windows/windows_iso.cfg
+++ b/config/windows/windows_iso.cfg
@@ -1,9 +1,11 @@
 # Windows 10, Windows 11
 # https://www.microsoft.com/software-download/
+# Tiny 10, Tiny 11
 
-iso_pattern="Win1*_*_x64*.iso"
+iso_pattern1="Win1*_*_x64*.iso"
+iso_pattern2="tiny1*.iso"
 
-for isofile in ($dev,*)$iso_dir/$iso_pattern; do
+for isofile in ($dev,*)$iso_dir/$iso_pattern1 ($dev,*)$iso_dir/$iso_pattern2; do
 	if [ -e "$isofile" ]; then
 		regexp --set=isoname "$iso_dir/(.*)" "$isofile"
 


### PR DESCRIPTION
I added pattern matching for Tiny11 to the windows cfg file and tested it. I have to look at the other cfg files to get their multiple pattern matching logic.

Resolves #81 